### PR TITLE
CI Updates

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,9 +20,6 @@ jobs:
           java-version: '11'
           cache: 'gradle'
 
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v2
-
       - uses: gradle/wrapper-validation-action@v1
       - run: ./gradlew --no-daemon build
         env:

--- a/examples/Counter/build.gradle.kts
+++ b/examples/Counter/build.gradle.kts
@@ -6,12 +6,6 @@ plugins {
 android {
     compileSdk = 32
 
-    androidComponents {
-        // exclude the release variant, failing in Github CI validateSigning
-        val release = selector().withBuildType("release")
-        beforeVariants(release) { variantBuilder -> variantBuilder.enable = false }
-    }
-
     defaultConfig {
         applicationId = "dev.alexbeggs.counter"
         minSdk = 23


### PR DESCRIPTION
- Remove android setup action (seems unnecessary)
- Re-enable the release variant, since this seemed to be caused by a lack of memory